### PR TITLE
fix(build): Add externals and disable devtool

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,9 @@ module.exports = {
   },
   plugins: [
     new DtsBundlePlugin()
-  ]
+  ],
+  externals: ['axios', 'node-cache'],
+  devtool: false
 };
 
 function DtsBundlePlugin() {}


### PR DESCRIPTION
Without externals webpack has been bundling all dependencies including
axios and node-cache resulting in a huge build size (265KB vs 7KB after the change).

This also was causing runtime error when used with existing axios installations. See #3.

Closes #3