### PR TITLE
get header value from response headers case insensitive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,16 @@ function getCacheByAxiosConfig(config: AxiosRequestConfig) {
   return Cache.get(getUUIDByAxiosConfig(config));
 }
 
+function getHeaderCaseInsensitive(headerName, headers) {
+  let value = null;
+  Object.keys(headers).forEach((header) => {
+    if (header.toLowerCase() === headerName.toLowerCase()) {
+      value = headers[header];
+    }
+  });
+  return value;
+}
+
 function requestInterceptor(config: AxiosRequestConfig) {
   if (isCacheableMethod(config)) {
     const uuid = getUUIDByAxiosConfig(config);
@@ -26,7 +36,7 @@ function requestInterceptor(config: AxiosRequestConfig) {
 
 function responseInterceptor(response: AxiosResponse) {
   if (isCacheableMethod(response.config)) {
-    const responseETAG = response.headers.etag;
+    const responseETAG = getHeaderCaseInsensitive('etag', response.headers);
     if (responseETAG) {
       Cache.set(getUUIDByAxiosConfig(response.config), responseETAG, response.data);
     }


### PR DESCRIPTION
Hi,

I really like your package, it gives pretty much value!

In your example and tests, getting the `etag` header value doesn't fail, because the `nock` package lower cases all headers. Perhaps you also have completely lower case headers in your production project, so this will work.

But if you have servers which deliver the `ETag` tag in some other upper-/lowercase or capitalized, your code fails, at least in my environment. As header fields may be case insensitive, you should determine them also case insensitive.

This is all about this PR - I've added a function to get header values in a case insensitive way. :-)