### PR TITLE
test if error has a response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function responseInterceptor(response: AxiosResponse) {
 }
 
 function responseErrorInterceptor(error: AxiosError) {
-  if (error.response.status === 304) {
+  if (error.response && error.response.status === 304) {
     const getCachedResult = getCacheByAxiosConfig(error.response.config);
     if (!getCachedResult) {
       return Promise.reject(error);


### PR DESCRIPTION
In case of cancelled axios requests, the error object doesn't have a response object, this would yield in an "...status of undefined..." error.
This PR fixes this possible "undefined" error.