### PR TITLE
Custom storage class and Post requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "build": "rollup -c",
     "clean": "rm -rf dist build",
     "lint": "eslint --max-warnings 0 . --ext .ts",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "npm run build"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,4 +1,17 @@
+export interface ConstructableCache<T> {
+  new(...args: any): T;
+}
+
 export abstract class BaseCache {
+  abstract get(key: string): CacheValue | undefined
+
+  abstract set(key: string, value: CacheValue)
+
+  abstract flushAll()
+
+}
+
+export class DefaultCache extends BaseCache {
   private cache = {};
 
   get(key: string): CacheValue | undefined {
@@ -12,9 +25,41 @@ export abstract class BaseCache {
   flushAll() {
     this.cache = {};
   }
+
+
 }
 
-export class DefaultCache extends BaseCache {
+export class LocalStorageClass extends BaseCache {
+  flushAll() {
+    for (let i = 0; i < localStorage.length; i++){
+      const key = localStorage.key(i);
+      if (key !== null && key.startsWith('aec-')) {
+        localStorage.removeItem(key);
+      }
+    }
+  }
+
+  get(key: string): CacheValue | undefined {
+    try {
+      const payload: string | null = localStorage.getItem('aec-' + key);
+      if (payload !== null) {
+        return JSON.parse(payload);
+      } else {
+        return undefined;
+      }
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  set(key: string, value: CacheValue) {
+    try {
+      const payload = JSON.stringify(value);
+      localStorage.setItem('aec-' + key, payload);
+    } catch (e) {
+      console.log(e);
+    }
+  }
 
 }
 
@@ -23,30 +68,46 @@ export interface CacheValue {
   value: any;
 }
 
-export class Cache {
-  static instance: Cache;
-  cache: BaseCache;
+/**
+ * The only instance of our Singleton
+ */
+let instance: ReturnType<typeof makeSingleton>;
 
-  static getInstance() {
-    if (!this.instance) {
-      this.instance = new Cache(new DefaultCache());
+let cache: BaseCache;
+
+/**
+ * Singleton supplies accessors using Revealing Module
+ * pattern and we use generics, since we could reuse
+ * this across multiple singletons
+ *
+ * Note: Object.freeze() not required due to type narrowing!
+ */
+const makeSingleton = (cacheClass: ConstructableCache<BaseCache>) => {
+  /** Closure of the singleton's value to keep it private */
+  cache = new cacheClass();
+  /** Only the accessors are returned */
+  return {
+    get(uuid: string): CacheValue | undefined {
+      return cache.get(uuid);
+    },
+    set(uuid: string, etag: string, value: any) {
+      return cache.set(uuid, { etag, value });
+    },
+    reset() {
+      cache.flushAll();
     }
-    return this.instance;
-  }
+  };
+};
 
-  static get(uuid: string): CacheValue | undefined {
-    return this.getInstance().cache.get(uuid);
+/**
+ * Retrieves the only instance of the Singleton
+ * and allows a once-only initialisation
+ * (additional changes require the setValue accessor)
+ */
+export const getCacheInstance = (cacheClass: ConstructableCache<BaseCache>) => {
+  if (!instance) {
+    instance = makeSingleton(cacheClass);
+    return instance;
   }
-
-  static set(uuid: string, etag: string, value: any) {
-    return this.getInstance().cache.set(uuid, { etag, value });
-  }
-
-  static reset() {
-    this.getInstance().cache.flushAll();
-  }
-
-  constructor(cache: BaseCache) {
-    this.cache = cache;
-  }
-}
+  return instance;
+};

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -29,7 +29,7 @@ export class DefaultCache extends BaseCache {
 
 }
 
-export class LocalStorageClass extends BaseCache {
+export class LocalStorageCache extends BaseCache {
   flushAll() {
     for (let i = 0; i < localStorage.length; i++){
       const key = localStorage.key(i);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,10 @@
 import { axiosETAGCache, getCacheByAxiosConfig, resetCache } from '../index';
 import nock from 'nock';
-import { Cache } from '../Cache';
 import axios from 'axios';
+import { DefaultCache, getCacheInstance } from '../Cache';
+
+const Cache = getCacheInstance(DefaultCache);
+
 
 const USERS = [{ uuid: '123', name: 'John' }];
 const TEST_ETAG_0 = '123ABC';
@@ -32,6 +35,7 @@ function replyIfNotEtagHeaders(request) {
 
 describe('Index', () => {
   describe('getCachedByAxiosConfig', () => {
+    axiosETAGCache(axios);
     it('should returns undefined when no config url is registered', () => {
       const config = {};
       Cache.get = jest.fn();

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export const getCacheByAxiosConfig = (config: AxiosRequestConfig) => {
   const url = getUrlByAxiosConfig(config);
   if (url) {
     if (config.data) {
-      const hash = cyrb53(config.data);
+      const hash = cyrb53(JSON.stringify(config.data));
       return Cache.get(hash + url);
     } else {
       return Cache.get(url);
@@ -38,7 +38,7 @@ function requestInterceptor(config: AxiosRequestConfig) {
     let lastCachedResult;
     if (config.data) {
       try {
-        const hash = cyrb53(config.data);
+        const hash = cyrb53(JSON.stringify(config.data));
         lastCachedResult = Cache.get(hash + url);
       } catch (e) {
         console.error(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export const getCacheByAxiosConfig = (config: AxiosRequestConfig) => {
   const url = getUrlByAxiosConfig(config);
   if (url) {
     if (config.data) {
-      const hash = cyrb53(JSON.stringify(config.data));
+      const hash = cyrb53(config.data);
       return Cache.get(hash + url);
     } else {
       return Cache.get(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,16 @@
-import { Cache } from './Cache';
-import { getHeaderCaseInsensitive } from './utils';
+
+import { axiosETAGCacheOptions, getHeaderCaseInsensitive } from './utils';
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import {DefaultCache, getCacheInstance} from './Cache';
+
+let Cache;
+let cacheableMethods = ['GET', 'HEAD'];
 
 function isCacheableMethod(config: AxiosRequestConfig) {
   if (!config.method) {
     return false;
   }
-  return ~['GET', 'HEAD'].indexOf(config.method.toUpperCase());
+  return ~cacheableMethods.indexOf(config.method.toUpperCase());
 }
 
 function getUrlByAxiosConfig(config: AxiosRequestConfig) {
@@ -67,7 +71,13 @@ export function resetCache() {
   Cache.reset();
 }
 
-export function axiosETAGCache(axiosInstance: AxiosInstance): AxiosInstance {
+export function axiosETAGCache(axiosInstance: AxiosInstance, options?: axiosETAGCacheOptions): AxiosInstance {
+  if (options?.cacheClass) {
+    Cache = getCacheInstance(options.cacheClass);
+  } else {
+    Cache = getCacheInstance(DefaultCache);
+  }
+
   axiosInstance.interceptors.request.use(requestInterceptor);
   axiosInstance.interceptors.response.use(responseInterceptor, responseErrorInterceptor);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,21 +15,17 @@ export const getHeaderCaseInsensitive = (headerName, headers = {}) => {
   return key ? headers[key] : undefined;
 };
 
-export const cyrb53 = function (object, seed = 0) {
-  if (!object) {
-    if (typeof object !== 'string' && !(object instanceof String)) {
-      console.error('Error cyrb53: object not defined');
-    }
-    return `${Date.now()}id`;
-  }
-  const str = JSON.stringify(object);
-  let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+export const cyrb53 = (str, seed = 0) => {
+  let h1 = 0xdeadbeef ^ seed,
+    h2 = 0x41c6ce57 ^ seed;
   for (let i = 0, ch; i < str.length; i++) {
     ch = str.charCodeAt(i);
     h1 = Math.imul(h1 ^ ch, 2654435761);
     h2 = Math.imul(h2 ^ ch, 1597334677);
   }
+
   h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
   h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(16).padStart(16, '0');
+
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,3 +14,22 @@ export const getHeaderCaseInsensitive = (headerName, headers = {}) => {
   const key = getKeys(headers).find(byLowerCase(headerName));
   return key ? headers[key] : undefined;
 };
+
+export const cyrb53 = function (object, seed = 0) {
+  if (!object) {
+    if (typeof object !== 'string' && !(object instanceof String)) {
+      console.error('Error cyrb53: object not defined');
+    }
+    return `${Date.now()}id`;
+  }
+  const str = JSON.stringify(object);
+  let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(16).padStart(16, '0');
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,8 @@ import { ConstructableCache } from './Cache';
 
 
 export interface axiosETAGCacheOptions {
-  cacheClass: ConstructableCache<any>
+  cacheClass?: ConstructableCache<any>
+  enablePost?: boolean
 }
 
 const byLowerCase = toFind => value => toLowerCase(value) === toFind;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,10 @@
+import { ConstructableCache } from './Cache';
+
+
+export interface axiosETAGCacheOptions {
+  cacheClass: ConstructableCache<any>
+}
+
 const byLowerCase = toFind => value => toLowerCase(value) === toFind;
 const toLowerCase = value => value.toLowerCase();
 const getKeys = headers => Object.keys(headers);


### PR DESCRIPTION
Hello!
I've added the ability to change the caching system thru a new options parameter. The options.cacheClass can be used pass a class extending BaseCache abstract class, for custom cache saving mechanism. I've also included the LocalStorageCache class which saves in the browser localStorage.
In some scenario can be useful to cache also the POST requests, options.enablePost will enable it. Post request are cached hashing the body content passed to the request. So different entries will be created for the same url but different payload.

Everything should be backward compatible with the previous versions.

const { axiosETAGCache, LocalStorageCache } = require("axios-etag-cache");
const axiosWithETAGCache = axiosETAGCache(axios, {   cacheClass: LocalStorageCache,   enablePost: true});

Andrea
